### PR TITLE
trustzone-sdk: update for new release 0.8.0

### DIFF
--- a/site/blog/2026-01-30-announcing-teaclave-trustzone-sdk-0.8.0.md
+++ b/site/blog/2026-01-30-announcing-teaclave-trustzone-sdk-0.8.0.md
@@ -1,0 +1,32 @@
+---
+title: Announcing Apache Teaclave™ TrustZone SDK 0.8.0
+date: 2026-01-30
+author: Yuan Zhuang
+---
+
+On behalf of the Teaclave community, I am happy to announce the release of
+Teaclave TrustZone SDK 0.8.0.
+
+Teaclave empowers developers to build memory-safe Trusted Applications across
+diverse confidential computing platforms, including Intel SGX and Arm TrustZone.
+Apache Teaclave TrustZone SDK, a subproject of Apache Teaclave, is based on the
+OP-TEE project, a widely used open-source TrustZone OS.
+
+This release focuses on tooling improvements, ecosystem polish, and better build
+compatibility, while keeping pace with upstream OP-TEE changes.
+
+For more details, please refer to our release notes:
+https://github.com/apache/teaclave-trustzone-sdk/releases/tag/v0.8.0
+
+## Download
+
+You can download the release from the
+[download](https://teaclave.apache.org/download/) page. Also, please checkout
+our [repository](https://github.com/apache/teaclave-trustzone-sdk) hosted on
+GitHub.
+
+## Contributing
+
+Teaclave TrustZone SDK is under the Apache License v2 and open source in The
+Apache Way. We aim to create a project that is maintained and owned by the
+community. All kinds of contributions are welcome. Thanks to our contributors.

--- a/site/docs/community/release-guide.md
+++ b/site/docs/community/release-guide.md
@@ -220,6 +220,20 @@ for details.
 
 ## Post the Release
 
+**Update the Teaclave website**
+
+The website source is at <https://github.com/apache/teaclave-website>. Open a PR
+to update.
+
+Add an announcement to <https://teaclave.apache.org/blog/> and update the latest
+version on the download page: <https://teaclave.apache.org/download/>.
+
+Blog example:
+
+- title: Announcing Apache Teaclave™ TrustZone SDK 0.6.0
+- link:
+  <https://teaclave.apache.org/blog/2025/09/12/announcing-teaclave-trustzone-sdk-0.6.0/>
+
 **Announce on the Apache mailing list**
 
 Mailing list example:
@@ -227,20 +241,6 @@ Mailing list example:
 - subject: [ANNOUNCE] Apache Teaclave™ TrustZone SDK 0.6.0 Released
 - to: announce@apache.org, dev@teaclave.apache.org
 - link: <https://lists.apache.org/thread/npxxtxxxolozjn15l5ff9nx6tltyt4o8>
-
-**Update the Teaclave website**
-
-The website source is at <https://github.com/apache/teaclave-website>. Open a PR
-to update.
-
-Add an announcement to <https://teaclave.apache.org/blog/> and update the
-download page: <https://teaclave.apache.org/download/>.
-
-Blog example:
-
-- title: Announcing Apache Teaclave™ TrustZone SDK 0.6.0
-- link:
-  <https://teaclave.apache.org/blog/2025/09/12/announcing-teaclave-trustzone-sdk-0.6.0/>
 
 After completing the steps above, the release process is finished.
 

--- a/site/src/pages/download.md
+++ b/site/src/pages/download.md
@@ -21,7 +21,7 @@ Each SDK evolves independently to best support its respective platform and use c
 
 | Latest Version | Source Code               | PGP/SHA | Release Notes |
 |:-------:|:-------------------------:|:----:|:-------:|
-| 0.7.0   | [apache-teaclave-trustzone-sdk-0.7.0.tar.gz](https://www.apache.org/dyn/closer.lua/teaclave/trustzone-sdk-0.7.0/apache-teaclave-trustzone-sdk-0.7.0.tar.gz?action=download) | [asc](https://downloads.apache.org/teaclave/trustzone-sdk-0.7.0/apache-teaclave-trustzone-sdk-0.7.0.tar.gz.asc), [sha512](https://downloads.apache.org/teaclave/trustzone-sdk-0.7.0/apache-teaclave-trustzone-sdk-0.7.0.tar.gz.sha512) | [notes](https://github.com/apache/teaclave-trustzone-sdk/releases/tag/v0.7.0) |
+| 0.8.0   | [apache-teaclave-trustzone-sdk-0.8.0.tar.gz](https://www.apache.org/dyn/closer.lua/teaclave/trustzone-sdk-0.8.0/apache-teaclave-trustzone-sdk-0.8.0.tar.gz?action=download) | [asc](https://downloads.apache.org/teaclave/trustzone-sdk-0.8.0/apache-teaclave-trustzone-sdk-0.8.0.tar.gz.asc), [sha512](https://downloads.apache.org/teaclave/trustzone-sdk-0.8.0/apache-teaclave-trustzone-sdk-0.8.0.tar.gz.sha512) | [notes](https://github.com/apache/teaclave-trustzone-sdk/releases/tag/v0.8.0) |
 
 ### Teaclave SGX SDK
 


### PR DESCRIPTION
Please note that I've also updated the announcement process in the Release Guide:
Previously, the order was: (1) send the announcement email, then (2) update the website.
However, since the announcement email should point to the website’s download page, the website update should be completed first to ensure the link is live for readers.