### PR TITLE
deploy: fix ci action error

### DIFF
--- a/.github/workflows/_reusable-build.yml
+++ b/.github/workflows/_reusable-build.yml
@@ -37,14 +37,14 @@ jobs:
           fetch-depth: 1
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3.7.1
+        uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f
         timeout-minutes: 5
         with:
           driver: docker-container
           install: true
 
       - name: Build Docker image
-        uses: docker/build-push-action@v6.9.0
+        uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8
         timeout-minutes: 30
         with:
           context: .

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,18 +1,18 @@
 # SGX Docs stage
-FROM teaclave/teaclave-build-ubuntu-1804-sgx-2.14:latest AS sgx-docs
+FROM teaclave/teaclave-build-ubuntu-2004-sgx-2.17.1:0.2.0 AS sgx-docs
 WORKDIR /app
+RUN (apt update || true) && apt install -y ca-certificates && update-ca-certificates
 COPY sgx-sdk-api-docs /app/sgx-sdk-api-docs
 RUN . "$HOME/.cargo/env" && cd sgx-sdk-api-docs && cargo doc
 RUN mkdir -p /prebuilt_docs && \
     cp -r sgx-sdk-api-docs/target/doc /prebuilt_docs/sgx-sdk-docs
 
 # Trustzone Docs stage
-FROM teaclave/teaclave-trustzone-emulator-std-optee-4.5.0-expand-memory:latest AS tz-docs
+FROM teaclave/teaclave-trustzone-emulator-std-expand-memory:latest AS tz-docs
 WORKDIR /app
 COPY tz-sdk-api-docs /app/tz-sdk-api-docs
 RUN . /opt/teaclave/setup/bootstrap_env && \
     . /opt/teaclave/environment && \
-    . $HOME/.cargo/env && \
     cd tz-sdk-api-docs && cargo doc
 RUN mkdir -p /prebuilt_docs && \
     cp -r tz-sdk-api-docs/target/doc /prebuilt_docs/tz-sdk-docs


### PR DESCRIPTION
Pin `setup-buildx-action` and `build-push-action` to allowed list versions.

fix:
[Error](https://github.com/apache/teaclave-website/actions/runs/26274807478)
The actions docker/setup-buildx-action@v3.7.1 and docker/build-push-action@v6.9.0 are not allowed in apache/teaclave-website because all actions must be from a repository owned by your enterprise

Reference:
- https://github.com/apache/rocketmq-docker/issues/125
- https://github.com/apache/infrastructure-actions/blob/main/approved_patterns.yml
